### PR TITLE
fix: mod buildId to avoid int32 overflow in package version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,17 @@ pool:
 
 steps:
 
+- task: PowerShell@2
+  displayName: 'Mod buildId to avoid int32 overflow'
+  inputs:
+    targetType: 'inline'
+    script: |
+      $buildID = $($env:BUILD_BUILDID)
+      $modBuildID = [int]$buildID % 65536  # ensure fits in int16
+      $newPackageVersion = "1.0.$modBuildID"
+      Write-Host "##vso[task.setvariable variable=packageVersion;]$newPackageVersion"
+      Write-Host "Updated packageVersion to '$newPackageVersion'"
+
 - task: NuGetToolInstaller@1
 
 - task: UseDotNet@2


### PR DESCRIPTION
Mirrors the fix applied in the curiosity-ai/catalyst pipeline so the
patch component stays within the 16-bit range required by .NET version
metadata once build IDs grow large enough to overflow.