### PR TITLE
fix: install mono before NuGet push on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,10 @@ steps:
     verbosityPack: 'Diagnostic'
     nobuild: true
 
-- task: DotNetCoreCLI@2
+- script: brew install mono
+  displayName: 'Install mono for NuGet push'
+
+- task: NuGetCommand@2
   displayName: 'push nuget'
   inputs:
     command: 'push'


### PR DESCRIPTION
DotNetCoreCLI push does not support encrypted API keys from service connections, so we need NuGetCommand. NuGetCommand on macOS shells out to nuget.exe via mono, which is no longer pre-installed on macOS-latest.

https://claude.ai/code/session_01BMdFXMtgWE8w4VZaQVgrti